### PR TITLE
v1.2.0 various fixes

### DIFF
--- a/Example/NYTViewController.m
+++ b/Example/NYTViewController.m
@@ -29,6 +29,18 @@ typedef NS_ENUM(NSUInteger, NYTViewControllerPhotoIndex) {
 
 @implementation NYTViewController
 
+#pragma mark - View lifecycle
+
+- (BOOL)shouldAutorotate {
+    return NO;
+}
+
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
+    return UIInterfaceOrientationMaskPortrait;
+}
+
+#pragma mark - Actions
+
 - (IBAction)imageButtonTapped:(id)sender {
     self.photos = [[self class] newTestPhotos];
     
@@ -38,6 +50,8 @@ typedef NS_ENUM(NSUInteger, NYTViewControllerPhotoIndex) {
     
     [self updateImagesOnPhotosViewController:photosViewController afterDelayWithPhotos:self.photos];
 }
+
+#pragma mark - Internal methods
 
 // This method simulates previously blank photos loading their images after some time.
 - (void)updateImagesOnPhotosViewController:(NYTPhotosViewController *)photosViewController afterDelayWithPhotos:(NSArray *)photos {

--- a/NYTPhotoViewer/NYTPhotoCaptionView.m
+++ b/NYTPhotoViewer/NYTPhotoCaptionView.m
@@ -58,15 +58,15 @@ static const CGFloat NYTPhotoCaptionViewVerticalMargin = 7.0;
 - (void)layoutSubviews {
     [super layoutSubviews];
 
-    void (^updateGradientFrame)() = ^{
+    if ([[[UIDevice currentDevice] systemVersion] floatValue] < 9.0f) {
+        // On iOS 8.x, when this view is height-constrained, neither `self.bounds` nor `self.layer.bounds` reflects the new layout height immediately after `[super layoutSubviews]`. Both of those properties appear correct in the next runloop.
+        // This problem doesn't affect iOS 9 and there may be a better solution; PRs welcome.
+        dispatch_async(dispatch_get_main_queue(), ^{
+            self.gradientLayer.frame = self.layer.bounds;
+        });
+    } else {
         self.gradientLayer.frame = self.layer.bounds;
-    };
-
-    updateGradientFrame();
-
-    // On iOS 8.x, when this view is height-constrained, neither `self.bounds` nor `self.layer.bounds` reflects the new layout height immediately after `[super layoutSubviews]`. Both of those properties appear correct in the next runloop.
-    // This problem doesn't affect iOS 9 and there may be a better solution; PRs welcome.
-    dispatch_async(dispatch_get_main_queue(), updateGradientFrame);
+    }
 }
 
 - (CGSize)intrinsicContentSize {

--- a/NYTPhotoViewer/NYTPhotoDismissalInteractionController.m
+++ b/NYTPhotoViewer/NYTPhotoDismissalInteractionController.m
@@ -25,8 +25,8 @@ static const CGFloat NYTPhotoDismissalInteractionControllerReturnToCenterVelocit
 - (void)didPanWithPanGestureRecognizer:(UIPanGestureRecognizer *)panGestureRecognizer viewToPan:(UIView *)viewToPan anchorPoint:(CGPoint)anchorPoint {
     UIView *fromView = [self.transitionContext viewForKey:UITransitionContextFromViewKey];
     CGPoint translatedPanGesturePoint = [panGestureRecognizer translationInView:fromView];
-    CGPoint newCenterPoint = CGPointMake(anchorPoint.x, anchorPoint.y + translatedPanGesturePoint.y);
-    
+    CGPoint newCenterPoint = CGPointMake(anchorPoint.x + translatedPanGesturePoint.x, anchorPoint.y + translatedPanGesturePoint.y);
+
     // Pan the view on pace with the pan gesture.
     viewToPan.center = newCenterPoint;
     
@@ -47,7 +47,7 @@ static const CGFloat NYTPhotoDismissalInteractionControllerReturnToCenterVelocit
     CGFloat velocityY = [panGestureRecognizer velocityInView:panGestureRecognizer.view].y;
     
     CGFloat animationDuration = (ABS(velocityY) * NYTPhotoDismissalInteractionControllerReturnToCenterVelocityAnimationRatio) + 0.2;
-    CGFloat animationCurve = UIViewAnimationOptionCurveEaseOut;
+    UIViewAnimationOptions animationCurve = UIViewAnimationOptionCurveEaseOut;
     CGPoint finalPageViewCenterPoint = anchorPoint;
     CGFloat finalBackgroundAlpha = 1.0;
     
@@ -161,6 +161,20 @@ static const CGFloat NYTPhotoDismissalInteractionControllerReturnToCenterVelocit
     self.viewToHideWhenBeginningTransition.alpha = 0.0;
     
     self.transitionContext = transitionContext;
+
+    UIView *fromView = [transitionContext viewForKey:UITransitionContextFromViewKey];
+    UIView *toView = [transitionContext viewForKey:UITransitionContextToViewKey];
+
+    UIViewController *toViewController = [transitionContext viewControllerForKey:UITransitionContextToViewControllerKey];
+    toView.frame = [transitionContext finalFrameForViewController:toViewController];
+
+    // when the presented view controller uses a full screen modal presentation style
+    // the presenter's view is removed from the window, so we add it back before
+    // transitioning
+    if (![toView isDescendantOfView:transitionContext.containerView]) {
+        [transitionContext.containerView addSubview:toView];
+        [transitionContext.containerView bringSubviewToFront:fromView];
+    }
 }
 
 @end

--- a/NYTPhotoViewer/NYTPhotoTransitionController.h
+++ b/NYTPhotoViewer/NYTPhotoTransitionController.h
@@ -30,6 +30,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic) BOOL forcesNonInteractiveDismissal;
 
+- (instancetype)initWithViewController:(UIViewController *)viewController NS_DESIGNATED_INITIALIZER;
+
 /**
  *  Call when new events are received from a `UIPanGestureRecognizer`. Internally passes off to interaction controller, which pans the appropriate view, and makes decisions when to finish or cancel the interactive transition back to the anchor point. Intended to be called after a dismissal has started with `dismissViewControllerAnimated:completion:`.
  *

--- a/NYTPhotoViewer/NYTPhotosViewController.m
+++ b/NYTPhotoViewer/NYTPhotosViewController.m
@@ -180,8 +180,11 @@ static const UIEdgeInsets NYTPhotosViewControllerCloseButtonImageInsets = {3, 0,
     _panGestureRecognizer = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(didPanWithGestureRecognizer:)];
     _singleTapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(didSingleTapWithGestureRecognizer:)];
 
-    _transitionController = [[NYTPhotoTransitionController alloc] init];
-    self.modalPresentationStyle = UIModalPresentationCustom;
+    _transitionController = [[NYTPhotoTransitionController alloc] initWithViewController:self];
+
+    // setting full screen modal presentation style, so the presenter's supported interface orientations
+    // don't condition this view controller's supported interface orientations
+    self.modalPresentationStyle = UIModalPresentationFullScreen;
     self.transitioningDelegate = _transitionController;
     self.modalPresentationCapturesStatusBarAppearance = YES;
 


### PR DESCRIPTION
- Changed taken approach in NYTPhotoCaptionView to only dispatch async if necessary.
- Allow a user to also pan horizontally the picture for interactive dismissal.
- Used a full screen modal presentation style, so NYTPhotosViewController can rotate independently from the presenter interface. Modified the example project's NYTViewController in order to make that explicit.
- When using a non interactive transition, ignore any interaction events until finished.
- Fixed bug where calling snapshotViewAfterScreenUpdates: was removing constraints from the snapshotted view.
- Fixed a bug when the final size of the presented view controller is different than the design size.
- Fixed bug in both interactive and non interactive dismissals, where the presenting view controller's image view was being shown during the animation (it was animating its setting of alpha to be zero).
- When dismissing in different orientations (from landscape to a portrait presenter or vice versa), force using a non interactive animation.